### PR TITLE
商品購入済みの機能の実装

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -81,6 +81,16 @@
         clear: both;
         }
       }
+    span{
+      position: absolute;
+      top: 37%;
+      left: 16%;
+      font-weight: bold;
+      font-size: 28px;
+      color:#fff;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+    }
     .view-all {
     width: 99.5%;
     padding: 20px 0 30px;

--- a/app/assets/stylesheets/_product_show.scss
+++ b/app/assets/stylesheets/_product_show.scss
@@ -112,6 +112,11 @@
     text-align: center;
     font-weight: bold;
     font-size: 24px;
+    &-disable{
+      @extend .item-box__buy;
+      background: #aaa;
+      border: 1px solid #aaa;
+    }
   }
   &__buy:hover {
     text-decoration: none;

--- a/app/assets/stylesheets/_product_show.scss
+++ b/app/assets/stylesheets/_product_show.scss
@@ -40,6 +40,16 @@
           height: 75px;
         }
       }
+      span{
+        position: absolute;
+        top: 37%;
+        left: 22%;
+        font-weight: bold;
+        font-size: 32px;
+        color:#fff;
+        background: #ea352d;
+        border: 1px solid #ea352d;
+      }
     }
     &-detail {
       float: right;

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -10,6 +10,7 @@ class BuysController < ApplicationController
     @product = Product.find(params[:product_id])
     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     charge = Payjp::Charge.create( amount: @product.price, card: params['payjp-token'], currency: 'jpy' )
+    @product.update_column(:sales_condition, '3')
     flash[:notice] =  "支払いが完了しました"
     redirect_to root_path
   end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -4,7 +4,7 @@
   %h1.item-box__name
     = @product.name
   %p.item-box__sub
-    = "『#{@product.name}』は、24回の取引実績を持つ#{@product.user.nickname}さんから出品されました。アネロ（リュック/バックパック/レディース）の商品で、#{Prefecture.data[@product.sales_condition].fetch(:name)}から#{Shippingday.data[@product.sales_condition].fetch(:name)}で発送されます。"
+    = "『#{@product.name}』は、24回の取引実績を持つ#{@product.user.nickname}さんから出品されました。アネロ（リュック/バックパック/レディース）の商品で、#{Prefecture.data[@product.ship_from.to_i].fetch(:name)}から#{Shippingday.data[@product.shipping_date.to_i].fetch(:name)}で発送されます。"
   .item-box__main.clearfix
     .item-box__main-photo
       %div
@@ -64,12 +64,21 @@
       = "￥" + number_with_delimiter(@product.price.to_s)
     %span.tax (税込)
     %span.shipping 送料込み
-  - if user_signed_in? && current_user.id == @product.user_id
-    =link_to 'この商品を編集する', edit_product_path , method: :get,class: "item-box__buy"
 
-    =link_to 'この商品を削除する', product_path , method: :delete,class: "item-box__buy", data: { confirm: "#{@product.name}を削除しますか？" }
-  - else
+  - if @product.sales_condition == 3
+    .item-box__buy-disable
+      %span 売り切れました
+
+  - elsif user_signed_in? && current_user.id != @product.user_id
     =link_to "購入画面に進む", new_product_buy_path(@product) ,method: :get, class: "item-box__buy"
+
+  - elsif user_signed_in? && current_user.id == @product.user_id
+    =link_to 'この商品を編集する', edit_product_path , method: :get,class: "item-box__buy"
+    =link_to 'この商品を削除する', product_path , method: :delete,class: "item-box__buy", data: { confirm: "#{@product.name}を削除しますか？" }
+
+  - else
+    =link_to "購入画面に進む",  new_user_session_path ,method: :get, class: "item-box__buy"
+
   .item-box__description
     %p
       = @product.product_description

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -9,9 +9,6 @@
     .item-box__main-photo
       %div
         = image_tag @product.image
-      / -if @product.sales_condition == 3
-      /   .item-box-sold-out-badge
-      /     %p SOLD OUT
       .photo
         = image_tag @product.image
       .photo

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -9,6 +9,9 @@
     .item-box__main-photo
       %div
         = image_tag @product.image
+      / -if @product.sales_condition == 3
+      /   .item-box-sold-out-badge
+      /     %p SOLD OUT
       .photo
         = image_tag @product.image
       .photo
@@ -17,6 +20,8 @@
         = image_tag @product.image
       .photo
         = image_tag @product.image
+      -if @product.sales_condition == 3
+        %span SOLD OUT
     %table.item-box__main-detail
       %tbody
         %tr

--- a/app/views/shared/_main.html.haml
+++ b/app/views/shared/_main.html.haml
@@ -17,5 +17,7 @@
                   ¥
                   = number_with_delimiter(product.price)
                 %p.items-box__tax (税込)
+            -if product.sales_condition == 3
+              %span SOLD OUT
       .view-all
         =link_to "すべての商品を見る", ''


### PR DESCRIPTION
# 概要
　商品購入済みの機能の実装

# 内容
・商品詳細画面での条件分岐
　⇨ログイン是非による表示ボタン変更
　⇨売り切れボタンの追加
・売り切れ済み商品へのSOLD_OUT